### PR TITLE
Fix doc moving groups

### DIFF
--- a/lib/lexorank/rankable.rb
+++ b/lib/lexorank/rankable.rb
@@ -60,9 +60,12 @@ module Lexorank::Rankable
         if position == 0
           [nil, collection.first]
         else
+          has_no_rank = !self.send(self.class.ranking_column)
+          current_position = collection.reload.map(&:id).index(self.id)
+          has_no_rank_in_group = current_position.nil?
           # if item is currently in front of the index we just use position otherwise position - 1
           # if the item has no rank we use position - 1
-          position -= 1 if !self.send(self.class.ranking_column) || collection.map(&:id).index(self.id) > position
+          position -= 1 if has_no_rank || has_no_rank_in_group || current_position > position
           collection.offset(position).limit(2)
         end
 

--- a/lib/lexorank/rankable.rb
+++ b/lib/lexorank/rankable.rb
@@ -60,12 +60,11 @@ module Lexorank::Rankable
         if position == 0
           [nil, collection.first]
         else
-          has_no_rank = !self.send(self.class.ranking_column)
-          current_position = collection.reload.map(&:id).index(self.id)
-          has_no_rank_in_group = current_position.nil?
+          current_position = collection.map(&:id).index(self.id)
+          not_in_collection = current_position.nil?
           # if item is currently in front of the index we just use position otherwise position - 1
           # if the item has no rank we use position - 1
-          position -= 1 if has_no_rank || has_no_rank_in_group || current_position > position
+          position -= 1 if no_rank? || not_in_collection || current_position > position
           collection.offset(position).limit(2)
         end
 
@@ -88,6 +87,9 @@ module Lexorank::Rankable
       move_to!(0)
     end
 
+    def no_rank?
+      !self.send(self.class.ranking_column)
+    end
   end
 
 end

--- a/test/group_by_test.rb
+++ b/test/group_by_test.rb
@@ -48,27 +48,27 @@ class GroupByTest < ActiveSupport::TestCase
   should 'insert an existing doc into a different group' do
     class Paragraph1 < ActiveRecord::Base
       self.table_name = "paragraphs"
+      belongs_to :page
       rank!(group_by: :page_id)
     end
 
-    page1, page2 = create_sample_pages(count: 2, clazz: Page)
-    paragraph1, paragraph2, paragraph3 = create_sample_pages(clazz: Paragraph1)
-    Paragraph1.update_all(page_id: page1.id)
+    page1, page2 = create_sample_pages(count: 2)
+    paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
 
-    create_sample_pages(count: 4, clazz: Paragraph1)
-    new_paragraph = Paragraph1.create!(page_id: page2.id)
-    new_paragraph.move_to!(1)
+    new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
 
-    new_paragraph.page_id = page1.id
+    new_paragraph.page = page1
     new_paragraph.move_to(2)
-    assert(new_paragraph.save!)
-    assert_equal [paragraph1, paragraph2, new_paragraph,  paragraph3], Paragraph1.where(page_id: page1.id).ranked
+    new_paragraph.save!
+
+    expected = [paragraph1, paragraph2, new_paragraph,  paragraph3]
+    assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
   end
 
-  def create_sample_paragraphs(page, count: 3)
+  def create_sample_paragraphs(page, count: 3, clazz: Paragraph)
     create_sample_docs(
       count: count,
-      clazz: Paragraph,
+      clazz: clazz,
       create_with: { page: page },
     )
   end

--- a/test/group_by_test.rb
+++ b/test/group_by_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class GroupByTest < ActiveSupport::TestCase
-
   should 'group paragraphs by page id and update accordingly' do
     page_1 = Page.create
     paragraphs_1 = create_sample_paragraphs(page_1)
@@ -20,11 +19,7 @@ class GroupByTest < ActiveSupport::TestCase
   end
 
   should 'resolve attribute names' do
-    class Paragraph1 < ActiveRecord::Base
-      self.table_name = "paragraphs"
-      rank!(group_by: :page_id)
-    end
-    assert_equal :page_id, Paragraph1.ranking_group_by
+    assert_equal :page_id, GroupedParagraph.ranking_group_by
 
     class Paragraph2 < ActiveRecord::Base
       self.table_name = "paragraphs"
@@ -46,52 +41,46 @@ class GroupByTest < ActiveSupport::TestCase
   end
 
   describe 'moving to a different group' do
-    class Paragraph1 < ActiveRecord::Base
-      self.table_name = "paragraphs"
-      belongs_to :page
-      rank!(group_by: :page_id)
-    end
-
     should 'insert into middle' do
       page1, page2 = create_sample_pages(count: 2)
-      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
+      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: GroupedParagraph)
 
-      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
+      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: GroupedParagraph).first
 
       new_paragraph.page = page1
       new_paragraph.move_to(2)
       new_paragraph.save!
 
       expected = [paragraph1, paragraph2, new_paragraph,  paragraph3]
-      assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
+      assert_equal expected, GroupedParagraph.where(page_id: page1.id).ranked
     end
 
     should 'insert at top' do
       page1, page2 = create_sample_pages(count: 2)
-      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
+      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: GroupedParagraph)
 
-      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
+      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: GroupedParagraph).first
 
       new_paragraph.page = page1
       new_paragraph.move_to(0)
       new_paragraph.save!
 
       expected = [new_paragraph, paragraph1, paragraph2,  paragraph3]
-      assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
+      assert_equal expected, GroupedParagraph.where(page_id: page1.id).ranked
     end
 
     should 'insert at the end' do
       page1, page2 = create_sample_pages(count: 2)
-      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
+      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: GroupedParagraph)
 
-      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
+      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: GroupedParagraph).first
 
       new_paragraph.page = page1
       new_paragraph.move_to(3)
       new_paragraph.save!
 
       expected = [paragraph1, paragraph2,  paragraph3, new_paragraph]
-      assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
+      assert_equal expected, GroupedParagraph.where(page_id: page1.id).ranked
     end
   end
 end

--- a/test/group_by_test.rb
+++ b/test/group_by_test.rb
@@ -45,31 +45,53 @@ class GroupByTest < ActiveSupport::TestCase
     assert_nil Paragraph3.ranking_group_by
   end
 
-  should 'insert an existing doc into a different group' do
+  describe 'moving to a different group' do
     class Paragraph1 < ActiveRecord::Base
       self.table_name = "paragraphs"
       belongs_to :page
       rank!(group_by: :page_id)
     end
 
-    page1, page2 = create_sample_pages(count: 2)
-    paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
+    should 'insert into middle' do
+      page1, page2 = create_sample_pages(count: 2)
+      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
 
-    new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
+      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
 
-    new_paragraph.page = page1
-    new_paragraph.move_to(2)
-    new_paragraph.save!
+      new_paragraph.page = page1
+      new_paragraph.move_to(2)
+      new_paragraph.save!
 
-    expected = [paragraph1, paragraph2, new_paragraph,  paragraph3]
-    assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
-  end
+      expected = [paragraph1, paragraph2, new_paragraph,  paragraph3]
+      assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
+    end
 
-  def create_sample_paragraphs(page, count: 3, clazz: Paragraph)
-    create_sample_docs(
-      count: count,
-      clazz: clazz,
-      create_with: { page: page },
-    )
+    should 'insert at top' do
+      page1, page2 = create_sample_pages(count: 2)
+      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
+
+      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
+
+      new_paragraph.page = page1
+      new_paragraph.move_to(0)
+      new_paragraph.save!
+
+      expected = [new_paragraph, paragraph1, paragraph2,  paragraph3]
+      assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
+    end
+
+    should 'insert at the end' do
+      page1, page2 = create_sample_pages(count: 2)
+      paragraph1, paragraph2, paragraph3 = create_sample_paragraphs(page1, clazz: Paragraph1)
+
+      new_paragraph = create_sample_paragraphs(page2, count: 1, clazz: Paragraph1).first
+
+      new_paragraph.page = page1
+      new_paragraph.move_to(3)
+      new_paragraph.save!
+
+      expected = [paragraph1, paragraph2,  paragraph3, new_paragraph]
+      assert_equal expected, Paragraph1.where(page_id: page1.id).ranked
+    end
   end
 end

--- a/test/models/grouped_paragraph.rb
+++ b/test/models/grouped_paragraph.rb
@@ -1,0 +1,5 @@
+class GroupedParagraph < Paragraph
+  rank!(group_by: :page_id)
+end
+
+

--- a/test/ranking_test.rb
+++ b/test/ranking_test.rb
@@ -71,23 +71,4 @@ class RankingTest < Minitest::Test
     assert_equal('This rank should not be achievable using the Lexorank::Rankable module! ' +
       'Please report to https://github.com/richardboehme/lexorank/issues! The supplied ranks were nil and "0". Please include those in the issue description.', error.message)
   end
-
-  should 'insert into top' do
-    class Paragraph1 < ActiveRecord::Base
-      self.table_name = "paragraphs"
-      rank!(group_by: :page_id)
-    end
-    page1, page2 = create_sample_pages(count: 2, clazz: Page)
-    paragraph1, paragraph2, paragraph3 = create_sample_pages(clazz: Paragraph1)
-    Paragraph1.update_all(page_id: page1.id)
-
-    create_sample_pages(count: 4, clazz: Paragraph1)
-    new_paragraph = Paragraph1.create!(page_id: page2.id)
-    new_paragraph.move_to!(1)
-
-    new_paragraph.page_id = page1.id
-    new_paragraph.move_to(2)
-    assert(new_paragraph.save!)
-    assert_equal [paragraph1, paragraph2, new_paragraph,  paragraph3], Paragraph1.where(page_id: page1.id).ranked
-  end
 end

--- a/test/ranking_test.rb
+++ b/test/ranking_test.rb
@@ -72,4 +72,22 @@ class RankingTest < Minitest::Test
       'Please report to https://github.com/richardboehme/lexorank/issues! The supplied ranks were nil and "0". Please include those in the issue description.', error.message)
   end
 
+  should 'insert into top' do
+    class Paragraph1 < ActiveRecord::Base
+      self.table_name = "paragraphs"
+      rank!(group_by: :page_id)
+    end
+    page1, page2 = create_sample_pages(count: 2, clazz: Page)
+    paragraph1, paragraph2, paragraph3 = create_sample_pages(clazz: Paragraph1)
+    Paragraph1.update_all(page_id: page1.id)
+
+    create_sample_pages(count: 4, clazz: Paragraph1)
+    new_paragraph = Paragraph1.create!(page_id: page2.id)
+    new_paragraph.move_to!(1)
+
+    new_paragraph.page_id = page1.id
+    new_paragraph.move_to(2)
+    assert(new_paragraph.save!)
+    assert_equal [paragraph1, paragraph2, new_paragraph,  paragraph3], Paragraph1.where(page_id: page1.id).ranked
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,4 +67,12 @@ class Minitest::Test
   def create_sample_pages(count: 3, clazz: Page)
     create_sample_docs(count: count, clazz: clazz)
   end
+
+  def create_sample_paragraphs(page, count: 3, clazz: Paragraph)
+    create_sample_docs(
+      count: count,
+      clazz: clazz,
+      create_with: { page: page },
+    )
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ load 'schema.rb'
 
 require 'models/page'
 require 'models/paragraph'
+require 'models/grouped_paragraph'
 
 class Minitest::Test
   include Shoulda::Context::DSL

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,16 +51,20 @@ class Minitest::Test
     assert !condition
   end
 
-  def create_sample_pages(count: 3, clazz: Page)
-    pages = []
+  def create_sample_docs(count:, clazz:, create_with: {})
+    docs = []
     count.times do
-      pages << clazz.create
+      docs << clazz.create(create_with)
     end
 
-    pages.each_with_index do |page, index|
-      page.move_to!(index)
+    docs.each_with_index do |doc, index|
+      doc.move_to!(index)
     end
 
-    pages
+    docs
+  end
+
+  def create_sample_pages(count: 3, clazz: Page)
+    create_sample_docs(count: count, clazz: clazz)
   end
 end


### PR DESCRIPTION
- add ability to move a record with an existing rank to a new group
- refactor group rank test and test helper to create docs
- refactor ranking method and group insert test
- add test cases for inserting at top and end in new group
- refactor Paragraph1 -> GroupedParagraph to avoid constant rename warnings
